### PR TITLE
fix(docs): remove already implemented feature from future developments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Assistant and solver for the game ["Word Play"](https://store.steampowered.com/a
 
 ### Future Features
 
--   Fix: prevent space or other non-tile symbols from being written.
 -   Add automatic "last updated" timestamp for when word list was last updated.
 -   Allow for multi-letter tiles (`ing`, `qu`, etc.).
 -   Allow for wildcard tiles.


### PR DESCRIPTION
Problem: Issue `Fix: prevent space or other non-tile symbols from being written` is already implemented but listed pending in Docs. [Reference](https://github.com/tampueroc/word-play-helper/blob/7950b0689bf19a43797b8cdd7e08d394082d9680/script.js#L58-L62)
Solution: Remove feature from Future Features list in README
